### PR TITLE
split operators

### DIFF
--- a/CHANGELOG-1.0.md
+++ b/CHANGELOG-1.0.md
@@ -7,6 +7,7 @@ in 1.0 minor versions.
 
  - bug #4 - fix phpunit configuration
  - feature #5 - add contributing file
+ - feature #7 - add Operators to Vocabulary
 
 ## 1.0.6 (2017-08-09)
 

--- a/src/Mado/QueryBundle/Queries/QueryBuilderFactory.php
+++ b/src/Mado/QueryBundle/Queries/QueryBuilderFactory.php
@@ -3,14 +3,13 @@
 namespace Mado\QueryBundle\Queries;
 
 use Doctrine\ORM\QueryBuilder;
+use Mado\QueryBundle\Vocabulary\Operators;
 
 class QueryBuilderFactory extends AbstractQuery
 {
     const DIRECTION_AZ = 'asc';
 
     const DIRECTION_ZA = 'desc';
-
-    const DEFAULT_OPERATOR = 'eq';
 
     /**
      * @var QueryBuilder
@@ -39,60 +38,9 @@ class QueryBuilderFactory extends AbstractQuery
 
     protected $select;
 
-    /** @todo move this file in configuration */
-    /** @todo type number|text */
-    private static $operatorMap = [
-        //'eq' => [
-            //'filtro' => '=',
-            //'tipo' => 'data|numero|stringa',
-            //'meta' => '%{foo}%'
-        //],
-        'eq' => [
-            'meta' => '=',
-        ],
-        'neq' => [
-            'meta' => '!=',
-        ],
-        'gt' => [
-            'meta' => '>',
-        ],
-        'gte' => [
-            'meta' => '>=',
-        ],
-        'lt' => [
-            'meta' => '<',
-        ],
-        'lte' => [
-            'meta' => '<=',
-        ],
-        'startswith' => [
-            'meta' => 'LIKE',
-            'substitution_pattern' => '{string}%'
-        ],
-        'contains' => [
-            'meta' => 'LIKE',
-            'substitution_pattern' => '%{string}%'
-        ],
-        'notcontains' => [
-            'meta' => 'NOT LIKE',
-            'substitution_pattern' => '%{string}%'
-        ],
-        'endswith' => [
-            'meta' => 'LIKE',
-            'substitution_pattern' => '%{string}'
-        ],
-        'list' => [
-            'meta' => 'IN',
-            'substitution_pattern' => '({string})',
-        ],
-        'field_eq' => [
-            'meta' => '=',
-        ],
-    ];
-
     public function getAvailableFilters()
     {
-        return array_keys(static::$operatorMap);
+        return array_keys(Operators::getAll());
     }
 
     public function setFields(array $fields = [])
@@ -263,9 +211,9 @@ class QueryBuilderFactory extends AbstractQuery
         $fieldName = $filterAndOperator[0];
         $fieldName = $this->parser->camelize($fieldName);
 
-        $operator = self::$operatorMap[self::DEFAULT_OPERATOR];
+        $operator = Operators::getDefaultOperator();
         if(isset($filterAndOperator[1])){
-            $operator = self::$operatorMap[$filterAndOperator[1]];
+            $operator = Operators::get($filterAndOperator[1]);
         }
 
         // controllo se il filtro che mi arriva dalla richiesta è una proprietà di questa entità
@@ -373,9 +321,9 @@ class QueryBuilderFactory extends AbstractQuery
         $fieldName = $filterAndOperator[0];
         $fieldName = $this->parser->camelize($fieldName);
 
-        $operator = self::$operatorMap[self::DEFAULT_OPERATOR];
+        $operator = Operators::getDefaultOperator();
         if(isset($filterAndOperator[1])){
-            $operator = self::$operatorMap[$filterAndOperator[1]];
+            $operator = Operators::get($filterAndOperator[1]);
         }
 
         // controllo se il filtro che mi arriva dalla richiesta è una proprietà di questa entità

--- a/src/Mado/QueryBundle/Vocabulary/Operators.php
+++ b/src/Mado/QueryBundle/Vocabulary/Operators.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Mado\QueryBundle\Vocabulary;
+
+class Operators
+{
+    const DEFAULT_OPERATOR = 'eq';
+
+    private static $operatorMap = [
+        'eq' => [
+            'meta' => '=',
+        ],
+        'neq' => [
+            'meta' => '!=',
+        ],
+        'gt' => [
+            'meta' => '>',
+        ],
+        'gte' => [
+            'meta' => '>=',
+        ],
+        'lt' => [
+            'meta' => '<',
+        ],
+        'lte' => [
+            'meta' => '<=',
+        ],
+        'startswith' => [
+            'meta' => 'LIKE',
+            'substitution_pattern' => '{string}%'
+        ],
+        'contains' => [
+            'meta' => 'LIKE',
+            'substitution_pattern' => '%{string}%'
+        ],
+        'notcontains' => [
+            'meta' => 'NOT LIKE',
+            'substitution_pattern' => '%{string}%'
+        ],
+        'endswith' => [
+            'meta' => 'LIKE',
+            'substitution_pattern' => '%{string}'
+        ],
+        'list' => [
+            'meta' => 'IN',
+            'substitution_pattern' => '({string})',
+        ],
+        'field_eq' => [
+            'meta' => '=',
+        ],
+    ];
+
+    public static function getAll()
+    {
+        return static::$operatorMap;
+    }
+
+    public static function getDefaultOperator()
+    {
+        return static::getAll()[static::DEFAULT_OPERATOR];
+    }
+
+    public static function get($operator)
+    {
+        return static::getAll()[$operator];
+    }
+}


### PR DESCRIPTION
| question | answer |
|---|---|
| backward compatibility? | yes|
| new feature? | no |
| bug fix? | no |
| new deprecations? | no |

Split all operator definitions in a separate files. Because of is a sort of dictionary, new `Mado\QueryBundle\Vocabulary` namespace were defined. In the "vocabulary" of QueryBundle, Operators are defined ...

- [x] split files
- [x] update changelog
- [x] squash everithing