### PR TITLE
remove ContainerAwareInterface implementation

### DIFF
--- a/CHANGELOG-1.0.md
+++ b/CHANGELOG-1.0.md
@@ -9,6 +9,7 @@ in 1.0 minor versions.
  - feature #5 - add contributing file
  - feature #7 - add Operators to Vocabulary
  - feature #8 - add new FilteringObject value
+ - bug #11 - remove ContainerAwareInterface from BaseRepository
 
 ## 1.0.6 (2017-08-09)
 

--- a/src/Mado/QueryBundle/Repositories/BaseRepository.php
+++ b/src/Mado/QueryBundle/Repositories/BaseRepository.php
@@ -13,10 +13,8 @@ use Mado\QueryBundle\Queries\QueryBuilderFactory;
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 
-class BaseRepository extends EntityRepository implements ContainerAwareInterface
+class BaseRepository extends EntityRepository
 {
-    use ContainerAwareTrait;
-
     protected $fields;
 
     protected $request;


### PR DESCRIPTION
| question | answer |
|---|---|
| backward compatibility? | yes|
| new feature? |no |
| bug fix? | yes|
| new deprecations? | no |

Actually the BaseRepository implement an interface that allow the use of container inside the baseRepository. But container is not used nor necessary.

- [x] update changelog