### PR TITLE
init properties array before using it

### DIFF
--- a/src/Mado/QueryBundle/Objects/FilteringObject.php
+++ b/src/Mado/QueryBundle/Objects/FilteringObject.php
@@ -26,6 +26,7 @@ final class FilteringObject
     {
         $filterAsArray = explode('|', $filter);
 
+        $properties = [];
         $properties[FilteringObject::KEY_FIELD_NAME] = $filterAsArray[FilteringObject::INDEX_FIELD_NAME];
 
         if (isset($filterAsArray[FilteringObject::INDEX_OPERATOR_NAME])) {


### PR DESCRIPTION
$properties was never initialized. Although not strictly required by PHP, it is generally a good practice to add $properties = array(); before regardless.