### PR TITLE
exlude generated files from coverage

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -9,12 +9,11 @@
 
     <filter>
         <whitelist processUncoveredFilesFromWhitelist="true">
-            <directory suffix=".php">src</directory>
-            <exclude>
-                <directory suffix="Test.php">src/Mado/QueryBundle/Tests</directory>
-                <directory suffix="Test.php">src/Mado/QueryBundle/DependencyInjection</directory>
-                <directory suffix="Test.php">src/Mado/QueryBundle/MadoQueryBundle.php</directory>
-            </exclude>
+            <directory suffix=".php">src/Mado/QueryBundle/Dictionary</directory>
+            <directory suffix=".php">src/Mado/QueryBundle/Queries</directory>
+            <directory suffix=".php">src/Mado/QueryBundle/Repositories</directory>
+            <directory suffix=".php">src/Mado/QueryBundle/Resources</directory>
+            <directory suffix=".php">src/Mado/QueryBundle/Services</directory>
         </whitelist>
     </filter>
 

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -12,6 +12,8 @@
             <directory suffix=".php">src</directory>
             <exclude>
                 <directory suffix="Test.php">src/Mado/QueryBundle/Tests</directory>
+                <directory suffix="Test.php">src/Mado/QueryBundle/DependencyInjection</directory>
+                <directory suffix="Test.php">src/Mado/QueryBundle/MadoQueryBundle.php</directory>
             </exclude>
         </whitelist>
     </filter>


### PR DESCRIPTION
## Purpose

Running coverage script appears some folders and files that contains generate files. The purpose of this pull request is to exlude those files and folders from coverage.

## Before

![schermata 2017-11-22 alle 10 07 11](https://user-images.githubusercontent.com/820248/33118836-5b4e4004-cf6d-11e7-8d5b-d41a725ad91e.png)

## After

![schermata 2017-11-22 alle 10 07 19](https://user-images.githubusercontent.com/820248/33118845-635bb772-cf6d-11e7-84b8-9c192d908534.png)

