### PR TITLE
fix #77 - filter could be different from list type

### DIFF
--- a/CHANGELOG-2.2.md
+++ b/CHANGELOG-2.2.md
@@ -3,3 +3,5 @@ CHANGELOG for 2.2
 
 This changelog references the relevant changes (bug and security fixes) done
 in 2.2 minor versions.
+
+ - fix #77 - filter could be different from list type

--- a/src/Mado/QueryBundle/Queries/Objects/Value.php
+++ b/src/Mado/QueryBundle/Queries/Objects/Value.php
@@ -15,19 +15,35 @@ final class Value
 
     public function getFilter()
     {
-        $filterCameFromQueryString = is_string($this->filter);
-
-        $isAdditionalFilter = !$filterCameFromQueryString;
-
-        if ($isAdditionalFilter) {
-            return $this->filter['list'][0];
+        if ($this->camesFromAdditionalFilters()) {
+            return $this->filter[$this->getOperator()][0];
         }
 
         return $this->filter;
     }
 
+    public function getValues()
+    {
+        return $this->filter[$this->getOperator()];
+    }
+
+    public function getOperator()
+    {
+        return key($this->filter);
+    }
+
     public static function fromFilter($filter)
     {
         return new self($filter);
+    }
+
+    public function camesFromQueryString()
+    {
+        return is_string($this->filter);
+    }
+
+    public function camesFromAdditionalFilters()
+    {
+        return !$this->camesFromQueryString();
     }
 }

--- a/tests/Mado/QueryBundle/Objects/ValueTest.php
+++ b/tests/Mado/QueryBundle/Objects/ValueTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Mado\QueryBundle\Tests\Objects;
+
+use Mado\QueryBundle\Queries\Objects\Value;
+use PHPUnit\Framework\TestCase;
+
+class ValueTest extends TestCase
+{
+    public function testLeaveFilterAsIsIfCamesFromQueryString()
+    {
+        $value = Value::fromFilter('foo');
+
+        $filter = $value->getFilter();
+
+        $this->assertEquals('foo', $filter);
+    }
+
+    public function testCamesFromQuerystringWheneverIsComposedByAString()
+    {
+        $value = Value::fromFilter('foo');
+
+        $this->assertSame(true, $value->camesFromQueryString());
+    }
+
+    public function testCamesFromAdditionalFiltersWheneverComposedByAnArray()
+    {
+        $value = Value::fromFilter(['op' => [1, 2, 3]]);
+
+        $this->assertSame(false, $value->camesFromQueryString());
+    }
+
+    public function testDetectOperator()
+    {
+        $value = Value::fromFilter(['op' => [1, 2, 3]]);
+
+        $this->assertEquals('op', $value->getOperator());
+    }
+
+    public function testDetectIds()
+    {
+        $value = Value::fromFilter(['op' => [1, 2, 3]]);
+
+        $this->assertEquals([1, 2, 3], $value->getValues());
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.2
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? |no
| Tests pass?   | yes

When created additional filters worked just as whitelist. Now each operator inside Dictionary can be used inside additional filters.