### PR TITLE
fix `since` annotation inside [Objects/Value] component

### DIFF
--- a/src/Mado/QueryBundle/Queries/Objects/Value.php
+++ b/src/Mado/QueryBundle/Queries/Objects/Value.php
@@ -3,7 +3,7 @@
 namespace Mado\QueryBundle\Queries\Objects;
 
 /**
- * @since Interface available since Release 2.1.3
+ * @since class available since release 2.1.3
  */
 final class Value
 {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.2
| Bug/Hotfix?   | yes
| Refactoring?  | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

Fix annotation that refers to an interface when in reality is a class ...