### PR TITLE
ensure query builder was initialized

### DIFF
--- a/CHANGELOG-2.2.md
+++ b/CHANGELOG-2.2.md
@@ -4,14 +4,6 @@ CHANGELOG for 2.2
 This changelog references the relevant changes (bug and security fixes) done
 in 2.2 minor versions.
 
-Enhancements
-------------
-
- - ensure query builder was initialized
-
-Fixes
------
-
  - resolve #79 - add new [FilterObject] component
  - fix #77 - undefined index list
  - fix #82 - anonymous method `setFilters` to more explicit `setAndFilters`

--- a/CHANGELOG-2.2.md
+++ b/CHANGELOG-2.2.md
@@ -4,6 +4,14 @@ CHANGELOG for 2.2
 This changelog references the relevant changes (bug and security fixes) done
 in 2.2 minor versions.
 
+Enhancements
+------------
+
+ - ensure query builder was initialized
+
+Fixes
+-----
+
  - resolve #79 - add new [FilterObject] component
  - fix #77 - undefined index list
  - fix #82 - anonymous method `setFilters` to more explicit `setAndFilters`

--- a/src/Mado/QueryBundle/Queries/QueryBuilderFactory.php
+++ b/src/Mado/QueryBundle/Queries/QueryBuilderFactory.php
@@ -429,6 +429,14 @@ class QueryBuilderFactory extends AbstractQuery
 
             if (in_array($fieldName, $this->fields)) {
                 $direction = ($val === self::DIRECTION_AZ) ? self::DIRECTION_AZ : self::DIRECTION_ZA;
+                if (!$this->qBuilder) {
+                    throw new \RuntimeException(
+                        'Oops! QueryBuilder was never initialized. '
+                        . "\n" . 'QueryBuilderFactory::createQueryBuilder()'
+                        . "\n" . 'QueryBuilderFactory::createSelectAndGroupBy()'
+                    );
+                }
+
                 $this->qBuilder->addOrderBy($this->entityAlias .'.'. $fieldName, $direction);
             }
 

--- a/src/Mado/QueryBundle/Queries/QueryBuilderFactory.php
+++ b/src/Mado/QueryBundle/Queries/QueryBuilderFactory.php
@@ -429,14 +429,7 @@ class QueryBuilderFactory extends AbstractQuery
 
             if (in_array($fieldName, $this->fields)) {
                 $direction = ($val === self::DIRECTION_AZ) ? self::DIRECTION_AZ : self::DIRECTION_ZA;
-                if (!$this->qBuilder) {
-                    throw new \RuntimeException(
-                        'Oops! QueryBuilder was never initialized. '
-                        . "\n" . 'QueryBuilderFactory::createQueryBuilder()'
-                        . "\n" . 'QueryBuilderFactory::createSelectAndGroupBy()'
-                    );
-                }
-
+                $this->ensureQueryBuilderIsDefined();
                 $this->qBuilder->addOrderBy($this->entityAlias .'.'. $fieldName, $direction);
             }
 
@@ -538,5 +531,16 @@ class QueryBuilderFactory extends AbstractQuery
     public function getEntityManager() : EntityManager
     {
         return $this->manager;
+    }
+
+    public function ensureQueryBuilderIsDefined()
+    {
+        if (!$this->qBuilder) {
+            throw new \RuntimeException(
+                'Oops! QueryBuilder was never initialized. '
+                . "\n" . 'QueryBuilderFactory::createQueryBuilder()'
+                . "\n" . 'QueryBuilderFactory::createSelectAndGroupBy()'
+            );
+        }
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.2
| Bug/Hotfix?   | yes
| Refactoring?  |no
| New feature?  | no
| BC breaks?    |no
| Deprecations? |no 
| Tests pass?   |no

 * qBuilder can be null and any exception is thrown whenever sorting is called without a valid query builder initialized
 * QueryBuilderFactory::sort() is now completely covered with tests