### PR TITLE
fix contributing 2.2

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,6 +1,11 @@
 Contributing
 ============
 
+Changelog
+---------
+
+ * every time new feature is added, new line on CHANGELOG file must be present;
+
 Choose the right branch
 -----------------------
 
@@ -9,13 +14,13 @@ work.
 
  * if it contains a bug fix, refactoring or simply some code improvements must
    be opened against latest minor release branch. If latest stable version is
-   v2.2.3, pull request must be opened starting from branch 2.2.
+   `v2.2.3`, pull request must be opened starting from branch 2.2;
 
    * every time new version is released, that version must be merged to the
      upper minor branch (if exists) until master branch. This allow to keep all
-     version fixed and also the next one.
+     version fixed and also the next one;
 
- * if it contains new features must be opened against master branch.
+ * if it contains new features must be opened against master branch;
 
 Coding Standards
 ----------------

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -4,8 +4,11 @@ Contributing
 Changelog
 ---------
 
- * every time new feature is added, new line on CHANGELOG file must be present;
+ * every time new feature is added, new line on CHANGELOG file must be present
+   in the form
 
+   > feature - feature description
+   
 Choose the right branch
 -----------------------
 


### PR DESCRIPTION
Contributing update ... Any new feature MUST HAVE a row in CHANGELOG. This must be explicit in CONTRIBUTING file. This PR will be applied to branch 2.2 and then merged up to 2.3 until master (2.4) according to CONTRIBUTING rules.