### PR TITLE
init Repository with MetaDataAdapter ad QueryBuilderOptions in one step

### DIFF
--- a/src/Mado/QueryBundle/Queries/AbstractQuery.php
+++ b/src/Mado/QueryBundle/Queries/AbstractQuery.php
@@ -3,6 +3,8 @@
 namespace Mado\QueryBundle\Queries;
 
 use Doctrine\ORM\EntityManager;
+use Mado\QueryBundle\Objects\MetaDataAdapter;
+use Mado\QueryBundle\Queries\QueryBuilderOptions;
 use Mado\QueryBundle\Services\StringParser;
 
 class AbstractQuery
@@ -49,5 +51,19 @@ class AbstractQuery
     public function getEntityName()
     {
         return $this->entityName;
+    }
+
+    public function loadMetadataAndOptions(
+        MetaDataAdapter $metadata,
+        QueryBuilderOptions $options
+    ) {
+        $this->setFields($metadata->getFields());
+
+        $this->setAndFilters($options->getAndFilters());
+        $this->setOrFilters($options->getOrFilters());
+        $this->setSorting($options->getSorting());
+        $this->setRel($options->getRel());
+        $this->setPrinting($options->getPrinting());
+        $this->setSelect($options->getSelect());
     }
 }

--- a/src/Mado/QueryBundle/Repositories/BaseRepository.php
+++ b/src/Mado/QueryBundle/Repositories/BaseRepository.php
@@ -50,13 +50,10 @@ class BaseRepository extends EntityRepository
             $this->metadata->getEntityAlias()
         );
 
-        $this->queryBuilderFactory->setFields($this->metadata->getFields());
-        $this->queryBuilderFactory->setAndFilters($options->getAndFilters());
-        $this->queryBuilderFactory->setOrFilters($options->getOrFilters());
-        $this->queryBuilderFactory->setSorting($options->getSorting());
-        $this->queryBuilderFactory->setRel($options->getRel());
-        $this->queryBuilderFactory->setPrinting($options->getPrinting());
-        $this->queryBuilderFactory->setSelect($options->getSelect());
+        $this->queryBuilderFactory->loadMetadataAndOptions(
+            $this->metadata,
+            $options
+        );
     }
 
     public function getQueryBuilderFactory()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.2
| Bug/Hotfix?   | no
| Refactoring?  | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

Wrap QueryBuilderFactory configuration possibile with one step instead of call each single setter.