### PR TITLE
Change default value for rel Option

### DIFF
--- a/src/Mado/QueryBundle/Queries/QueryBuilderOptions.php
+++ b/src/Mado/QueryBundle/Queries/QueryBuilderOptions.php
@@ -45,7 +45,7 @@ class QueryBuilderOptions
 
     public function getRel()
     {
-        return $this->get('rel');
+        return $this->get('rel', []);
     }
 
     public function getPrinting()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.3
| Bug/Hotfix?   | yes
| Refactoring?  | no
| New feature?  | no <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md files -->
| Tests pass?   | yes

<!-- Bug fixes must be submitted against the minor branch affected         -->
<!-- features and deprecations must be submitted against the master branch -->
<!-- Replace this comment by a description of what your PR is solving      -->

when the rel value in the url is not specified, the following error is generated:

Argument 1 passed to Mado\QueryBundle\Queries\QueryBuilderFactory::setRel() must be of the type array, null given, called in /Users/saverio/workspace/mg_api/vendor/studiomado/query-bundle/src/Mado/QueryBundle/Queries/AbstractQuery.php on line 65
