### PR TITLE
resolve #114 - convert negative limit to PHP_INT_MAX

### DIFF
--- a/CHANGELOG-2.2.md
+++ b/CHANGELOG-2.2.md
@@ -9,3 +9,4 @@ in 2.2 minor versions.
  - fix #82 - anonymous method `setFilters` to more explicit `setAndFilters`
  - fix #95 - remove `Mado\QueryBundle\Queries\Objects\Operator` statement
  - fix #96 - remove variable assignment 'cause its unused
+ - fix #114 - convert negative limit to PHP_INT_MAX

--- a/src/Mado/QueryBundle/Queries/QueryBuilderOptions.php
+++ b/src/Mado/QueryBundle/Queries/QueryBuilderOptions.php
@@ -18,6 +18,12 @@ class QueryBuilderOptions
 
     public function get($option, $defaultValue = null)
     {
+        if ('limit' == $option) {
+            if (-1 == $this->options[$option]) {
+                $this->options[$option] = PHP_INT_MAX;
+            }
+        }
+
         if (
             !isset($this->options[$option])
             || empty($this->options[$option])

--- a/src/Mado/QueryBundle/Queries/QueryBuilderOptions.php
+++ b/src/Mado/QueryBundle/Queries/QueryBuilderOptions.php
@@ -19,7 +19,7 @@ class QueryBuilderOptions
     public function get($option, $defaultValue = null)
     {
         if ('limit' == $option) {
-            if (-1 == $this->options[$option]) {
+            if ($this->options[$option] < 0) {
                 $this->options[$option] = PHP_INT_MAX;
             }
         }

--- a/src/Mado/QueryBundle/Queries/QueryBuilderOptions.php
+++ b/src/Mado/QueryBundle/Queries/QueryBuilderOptions.php
@@ -18,11 +18,7 @@ class QueryBuilderOptions
 
     public function get($option, $defaultValue = null)
     {
-        if ('limit' == $option) {
-            if ($this->options[$option] < 0) {
-                $this->options[$option] = PHP_INT_MAX;
-            }
-        }
+        $this->validateOption($option, $defaultValue);
 
         if (
             !isset($this->options[$option])
@@ -62,5 +58,17 @@ class QueryBuilderOptions
     public function getSelect()
     {
         return $this->get('select');
+    }
+
+    public function validateOption($option, $defaultValue)
+    {
+        $optionIsDefinedNegativeAndNotNull = (
+            !isset($this->options[$option])
+            || $this->options[$option] < 0
+        ) && $defaultValue == null;
+
+        if ('limit' == $option && $optionIsDefinedNegativeAndNotNull) {
+            $this->options[$option] = PHP_INT_MAX;
+        }
     }
 }

--- a/tests/Mado/QueryBundle/Queries/QueryBuilderOptionsTest.php
+++ b/tests/Mado/QueryBundle/Queries/QueryBuilderOptionsTest.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Mado\QueryBundle\Tests\Queries;
+
+use Mado\QueryBundle\Queries\QueryBuilderOptions;
+use PHPUnit\Framework\TestCase;
+
+class QueryBuilderOptionsTest extends TestCase
+{
+    public function testConvertNegativeLimitToInfinite()
+    {
+        $options = QueryBuilderOptions::fromArray([
+            'limit' => -1,
+        ]);
+        $this->assertEquals(PHP_INT_MAX, $options->get('limit'));
+    }
+}

--- a/tests/Mado/QueryBundle/Queries/QueryBuilderOptionsTest.php
+++ b/tests/Mado/QueryBundle/Queries/QueryBuilderOptionsTest.php
@@ -12,4 +12,16 @@ class QueryBuilderOptionsTest extends TestCase
         $options = QueryBuilderOptions::fromArray(['limit' => -1]);
         $this->assertEquals(PHP_INT_MAX, $options->get('limit'));
     }
+
+    public function testUndefinedLimitMeansInfiniteByDefault()
+    {
+        $options = QueryBuilderOptions::fromArray([]);
+        $this->assertEquals(PHP_INT_MAX, $options->get('limit'));
+    }
+
+    public function testGetDefaultValueIfNotSpecified()
+    {
+        $options = QueryBuilderOptions::fromArray([]);
+        $this->assertEquals(42, $options->get('limit', 42));
+    }
 }

--- a/tests/Mado/QueryBundle/Queries/QueryBuilderOptionsTest.php
+++ b/tests/Mado/QueryBundle/Queries/QueryBuilderOptionsTest.php
@@ -9,9 +9,7 @@ class QueryBuilderOptionsTest extends TestCase
 {
     public function testConvertNegativeLimitToInfinite()
     {
-        $options = QueryBuilderOptions::fromArray([
-            'limit' => -1,
-        ]);
+        $options = QueryBuilderOptions::fromArray(['limit' => -1]);
         $this->assertEquals(PHP_INT_MAX, $options->get('limit'));
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.2
| Bug/Hotfix?   | yes
| Refactoring?  | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes/no

Just convert negative limit number to PHP_INT_MAX.