### PR TITLE
add Makefile to run tests and install tasks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,7 @@
+.QUERYBUNDLE: runtests
+runtests: install
+	php bin/phpunit -c phpunit.xml
+
+.QUERYBUNDLE: install
+install:
+	composer install


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug/Hotfix?   | no
| Refactoring?  | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? |no
| Tests pass?   | yes

This PR aims to introduce Makefile. Why so old tool can be useful today? First of all 'cause all of us now need to remember commands to run like

 - rebuild.sh
 - runtests.sh
 - dosomething.sh
 - dosomethingelse.sh
 - ...

Adding this line of code in our `dotfiles`:

> complete -W "\`grep -oE '^[a-zA-Z0-9_.-]+:([^=]|$)' Makefile | sed 's/[^a-zA-Z0-9_.-]*$//'\`" make

bash can autotocomplete all Makefile targets. What is a Makefile target? Are label like

 - this_is_target
 - this_is_another_target

```
.MADO: this_is_target
this_is_target:
    echo "foo
.MADO: this_is_another_target
this_is_another_target:
    echo "bar
```

Finally, ... I think just one file could be better than more sh files.