### PR TITLE
Update CONTRIBUTING.md

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -15,9 +15,12 @@ Choose the right branch
 Before open your pull request, you must determine on which branch you need to
 work.
 
- * if it contains a bug fix, refactoring or simply some code improvements must
-   be opened against latest minor release branch. If latest stable version is
+ * if it contains a fix, refactoring or simply some code improvements must be
+   opened against latest minor release branch. If latest stable version is
    `v2.2.3`, pull request must be opened starting from branch 2.2;
+     
+   * once new branch is merged to version 2.2 a new tag can should be created
+     in this branch.
 
    * every time new version is released, that version must be merged to the
      upper minor branch (if exists) until master branch. This allow to keep all


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master (2.5)
| Bug/Hotfix?   |  yes
| Refactoring?  | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

There is a bit of confusion and we are creating useless new minor tags. Until we keep same features we should keep same minor version. To remove confusione steps to create new bugfix should be:

 - check latest stable version affected (i.e. tag v5.6.7)
 - checkout minor release branch (branch 5.6)
 - resolve against that minor release
 - once PR is approved ...
   - release new tag v5.6.8
   - merge branch 5.6 to master