### PR TITLE
or filter generate left join instead of inner join

### DIFF
--- a/CHANGELOG-2.4.md
+++ b/CHANGELOG-2.4.md
@@ -1,0 +1,7 @@
+CHANGELOG for 2.4
+=================
+
+This changelog references the relevant changes (bug and security fixes) done
+in 2.4 minor versions.
+
+ - fix - or filter generate left join instead of inner join  

--- a/src/Mado/QueryBundle/Queries/QueryBuilderFactory.php
+++ b/src/Mado/QueryBundle/Queries/QueryBuilderFactory.php
@@ -17,6 +17,10 @@ class QueryBuilderFactory extends AbstractQuery
 
     const DEFAULT_OPERATOR = 'eq';
 
+    private const AND_OPERATOR_LOGIC = 'AND';
+
+    private const OR_OPERATOR_LOGIC = 'OR';
+
     protected $qBuilder;
 
     protected $fields;
@@ -122,7 +126,7 @@ class QueryBuilderFactory extends AbstractQuery
      * @param String $relation Nome della relazione semplice (groups.name) o con embedded (_embedded.groups.name)
      * @return $this
      */
-    public function join(String $relation, $logicOperator = 'AND')
+    public function join(String $relation, $logicOperator = self::AND_OPERATOR_LOGIC)
     {
         $relation = explode('|', $relation)[0];
         $relations = [$relation];
@@ -157,9 +161,9 @@ class QueryBuilderFactory extends AbstractQuery
                 $fieldName = $this->parser->camelize($association['fieldName']);
 
                 if ($this->noExistsJoin($relationEntityAlias, $relation)) {
-                    if ($logicOperator == 'AND') {
+                    if ($logicOperator === self::AND_OPERATOR_LOGIC) {
                         $this->qBuilder->innerJoin($entityAlias . "." . $fieldName, $relationEntityAlias);
-                    } elseif ($logicOperator == 'OR') {
+                    } elseif ($logicOperator === self::OR_OPERATOR_LOGIC) {
                         $this->qBuilder->leftJoin($entityAlias . "." . $fieldName, $relationEntityAlias);
                     } else {
                         throw new Exceptions('Missing Logic operator');
@@ -361,7 +365,7 @@ class QueryBuilderFactory extends AbstractQuery
         // esempio per users: filtering[_embedded.groups.name|eq]=admin
         if (strstr($filterObject->getRawFilter(), '_embedded.')) {
 
-            $this->join($filterObject->getRawFilter(), 'OR');
+            $this->join($filterObject->getRawFilter(), self::OR_OPERATOR_LOGIC);
             $relationEntityAlias = $this->getRelationEntityAlias();
 
             $embeddedFields = explode('.', $filterObject->getFieldName());

--- a/tests/Mado/QueryBundle/Objects/QueryBuilderFactoryTest.php
+++ b/tests/Mado/QueryBundle/Objects/QueryBuilderFactoryTest.php
@@ -632,30 +632,10 @@ class QueryBuilderFactoryTest extends TestCase
         );
     }
 
-    public function testAndFilterGenerateInnerJoin()
+    public function testAndFilterUseInnerJoin()
     {
-        $this->prepareDataForFilter('innerJoin');
+        $expectJoinType = 'innerJoin';
 
-        $queryBuilderFactory = new QueryBuilderFactory($this->manager);
-        $queryBuilderFactory->setFields([ 'id' ]);
-        $queryBuilderFactory->createQueryBuilder('EntityName', 'alias');
-        $queryBuilderFactory->setAndFilters([ '_embedded.foo.baz|eq' => 'bar' ]);
-        $queryBuilderFactory->filter();
-    }
-
-    public function testOrFilterGenerateLeftJoin()
-    {
-        $this->prepareDataForFilter('leftJoin');
-
-        $queryBuilderFactory = new QueryBuilderFactory($this->manager);
-        $queryBuilderFactory->setFields([ 'id' ]);
-        $queryBuilderFactory->createQueryBuilder('EntityName', 'alias');
-        $queryBuilderFactory->setOrFilters([ '_embedded.foo.baz|eq' => 'bar' ]);
-        $queryBuilderFactory->filter();
-    }
-
-    private function prepareDataForFilter($joinType)
-    {
         $this->queryBuilder = $this
             ->getMockBuilder('Doctrine\ORM\QueryBuilder')
             ->disableOriginalConstructor()
@@ -667,9 +647,47 @@ class QueryBuilderFactoryTest extends TestCase
             ->method('from')
             ->willReturn($this->queryBuilder);
         $this->queryBuilder->expects($this->once())
-            ->method($joinType)
+            ->method($expectJoinType)
             ->with('alias.baz', 'table_foo');
 
+        $this->prepareDataForFilter();
+
+        $queryBuilderFactory = new QueryBuilderFactory($this->manager);
+        $queryBuilderFactory->setFields([ 'id' ]);
+        $queryBuilderFactory->createQueryBuilder('EntityName', 'alias');
+        $queryBuilderFactory->setAndFilters([ '_embedded.foo.baz|eq' => 'bar' ]);
+        $queryBuilderFactory->filter();
+    }
+
+    public function testOrFilterUseLeftJoin()
+    {
+        $expectJoinType = 'leftJoin';
+
+        $this->queryBuilder = $this
+            ->getMockBuilder('Doctrine\ORM\QueryBuilder')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->queryBuilder
+            ->method('select')
+            ->willReturn($this->queryBuilder);
+        $this->queryBuilder
+            ->method('from')
+            ->willReturn($this->queryBuilder);
+        $this->queryBuilder->expects($this->once())
+            ->method($expectJoinType)
+            ->with('alias.baz', 'table_foo');
+
+        $this->prepareDataForFilter();
+
+        $queryBuilderFactory = new QueryBuilderFactory($this->manager);
+        $queryBuilderFactory->setFields([ 'id' ]);
+        $queryBuilderFactory->createQueryBuilder('EntityName', 'alias');
+        $queryBuilderFactory->setOrFilters([ '_embedded.foo.baz|eq' => 'bar' ]);
+        $queryBuilderFactory->filter();
+    }
+
+    private function prepareDataForFilter()
+    {
         $this->metadata = $this
             ->getMockBuilder('Doctrine\ORM\Mapping\ClassMetadata')
             ->disableOriginalConstructor()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.4
| Bug/Hotfix?   | yes
| Refactoring?  | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

Fixed bug on or filter, now it generates a left join instead of inner join

Resolve #122 
