### PR TITLE
move paginate function into a service

### DIFF
--- a/src/Mado/QueryBundle/Objects/PagerfantaBuilder.php
+++ b/src/Mado/QueryBundle/Objects/PagerfantaBuilder.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Mado\QueryBundle\Objects;
+
+use Hateoas\Representation\Factory\PagerfantaFactory;
+use Pagerfanta\Adapter\DoctrineORMAdapter;
+use Pagerfanta\Pagerfanta;
+
+class PagerfantaBuilder
+{
+    private $pagerfantaFactory;
+
+    private $ormAdapter;
+
+    public function __construct(PagerfantaFactory $pagerfantaFactory, DoctrineORMAdapter $ormAdapter)
+    {
+        $this->pagerfantaFactory = $pagerfantaFactory;
+        $this->ormAdapter = $ormAdapter;
+    }
+
+    public function create($limit, $page) :Pagerfanta
+    {
+        $pager = new Pagerfanta($this->ormAdapter);
+        $pager->setNormalizeOutOfRangePages(true);
+        $pager->setMaxPerPage($limit);
+        $pager->setCurrentPage($page);
+
+        return $pager;
+    }
+
+    public function createRepresentation($route, $limit, $page)
+    {
+        $pager = $this->create(
+            $limit,
+            $page
+        );
+
+        return $this->pagerfantaFactory->createRepresentation($pager, $route);
+    }
+}

--- a/src/Mado/QueryBundle/Services/Pager.php
+++ b/src/Mado/QueryBundle/Services/Pager.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Mado\QueryBundle\Services;
+
+use Mado\QueryBundle\Objects\PagerfantaBuilder;
+use Mado\QueryBundle\Queries\QueryBuilderOptions;
+use Pagerfanta\Adapter\DoctrineORMAdapter;
+
+class Pager
+{
+    private const DEFAULT_LIMIT = 10;
+
+    private const DEFAULT_PAGE = 1;
+
+    private const DEFAULT_LIFETIME = 600;
+
+    private $router;
+
+    public function __construct()
+    {
+        $this->setRouter(new Router());
+    }
+
+    public function setRouter(Router $router)
+    {
+        $this->router = $router;
+    }
+
+    public function paginateResults (
+        QueryBuilderOptions $queryOptions,
+        DoctrineORMAdapter $ormAdapter,
+        PagerfantaBuilder $pagerfantaBuilder,
+        $routeName,
+        $useResultCache
+    ) {
+        $limit = $queryOptions->get('limit', self::DEFAULT_LIMIT);
+        $page = $queryOptions->get('page', self::DEFAULT_PAGE);
+
+        $query = $ormAdapter->getQuery();
+        if (isset($useResultCache) && $useResultCache) {
+            $query->useResultCache(true, self::DEFAULT_LIFETIME);
+        }
+
+        $route = $this->router->createRouter($queryOptions, $routeName);
+
+        return $pagerfantaBuilder->createRepresentation($route, $limit, $page);
+    }
+}

--- a/tests/Mado/QueryBundle/Services/PagerTest.php
+++ b/tests/Mado/QueryBundle/Services/PagerTest.php
@@ -1,0 +1,132 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+use Mado\QueryBundle\Services\Pager;
+
+class PagerTest extends TestCase
+{
+    private $pagerfantaFactoryMock;
+
+    private $router;
+
+    private $pager;
+
+    private $queryBuilder;
+
+    private $queryBuilderOptions;
+
+    private $pagerfantaBuilder;
+
+    private $doctrineOrmAdapter;
+
+    private $query;
+
+    public function setUp()
+    {
+        $this->pagerfantaFactoryMock = $this
+            ->getMockBuilder(\Hateoas\Representation\Factory\PagerfantaFactory::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->router = $this
+            ->getMockBuilder(\Mado\QueryBundle\Services\Router::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->queryBuilder = $this
+            ->getMockBuilder(\Doctrine\ORM\QueryBuilder::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->queryBuilderOptions = $this
+            ->getMockBuilder(\Mado\QueryBundle\Queries\QueryBuilderOptions::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->pagerfantaBuilder = $this
+            ->getMockBuilder(\Mado\QueryBundle\Objects\PagerfantaBuilder::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->doctrineOrmAdapter = $this
+            ->getMockBuilder(\Pagerfanta\Adapter\DoctrineORMAdapter::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->query = $this
+            ->getMockBuilder(\Doctrine\ORM\AbstractQuery::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->pagerfanta = $this
+            ->getMockBuilder(\Pagerfanta\Pagerfanta::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->doctrineOrmAdapter
+            ->method('getQuery')
+            ->willReturn($this->query);
+
+        $this->queryBuilderOptions
+            ->expects($this->at(0))
+            ->method('get')
+            ->with('limit')
+            ->willReturn(1);
+
+        $this->queryBuilderOptions
+            ->expects($this->at(1))
+            ->method('get')
+            ->with('page')
+            ->willReturn(1);
+
+        $this->pagerfantaBuilder
+            ->method('create')
+            ->willReturn($this->pagerfanta);
+
+        $this->pagerfantaBuilder
+            ->method('createRepresentation')
+            ->willReturn(true);
+
+        $this->pager = new Pager();
+    }
+
+    public function testPaginateWithoutCache()
+    {
+        $this->query
+            ->expects($this->never())
+            ->method('useResultCache');
+
+        $routeName = 'foo';
+        $useCache = null;
+
+        $this->pager->setRouter($this->router);
+
+        $this->pager->paginateResults(
+            $this->queryBuilderOptions,
+            $this->doctrineOrmAdapter,
+            $this->pagerfantaBuilder,
+            $routeName,
+            $useCache
+        );
+    }
+
+    public function testPaginateWithCache()
+    {
+        $this->query
+            ->expects($this->once())
+            ->method('useResultCache');
+
+        $routeName = 'foo';
+        $useCache = true;
+
+        $this->pager->setRouter($this->router);
+
+        $this->pager->paginateResults(
+            $this->queryBuilderOptions,
+            $this->doctrineOrmAdapter,
+            $this->pagerfantaBuilder,
+            $routeName,
+            $useCache
+        );
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Minor version?      | 2.4
| Hotfix?       | no
| Refactoring?  | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

Move paginateResults function into a proper service

I think that we need to change something but I would like to discuss how to improve now the code @sensorario .
For example to include pagerfantaFactory into pagerfantaBuilder so from pager you call only our pagerfantaBuilder and remove a dependency.
Many improvement could be done here I think
