### PR TITLE
add find all without pagination

### DIFF
--- a/CHANGELOG-2.4.md
+++ b/CHANGELOG-2.4.md
@@ -8,3 +8,4 @@ in 2.4 minor versions.
  - feature - added operator isnull and isnotnull
  - fix - don't adding parameters in filter or if operator is null type
  - feature - added operator listcontains
+ - feature - [BaseRepository] added find all no paginated method 

--- a/README.md
+++ b/README.md
@@ -176,3 +176,49 @@ Here some examples:
  - http://127.0.0.1:8000/?filtering[status]=todo
  - http://127.0.0.1:8000/?filtering[status|contains]=od
  - http://127.0.0.1:8000/?filtering[status|endswith]=gress
+
+# Find All No Paginated
+
+Added a new method in **BaseRepository**  
+When you need results applying filter and sort without pagination
+```
+public function findAllNoPaginated();
+```
+This feature was needed to create an Excel Report, injecting results into the Excel Report
+
+Example without pagination
+--------------------------
+In Controller:
+```
+public function getTasksExcelReportAction(Request $request)
+    {
+        $tasks = $this->getDoctrine()
+            ->getRepository('AppBundle:Task')
+            ->findAllNoPaginated();
+        
+        $reportExcel = new TasksReport($tasks);
+        $reportExcel->createReport();
+        
+        $excelContent = $reportExcel->printReport();
+        
+        return new Response(
+            $excelContent,
+            200, [
+                'Content-Type' => 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+            ]
+        );        
+    } 
+```  
+
+Example with pagination
+-----------------------
+In Controller:
+```
+    public function getTasksAction(Request $request)
+    {
+        return $this->getDoctrine()
+            ->getRepository('AppBundle:Task')
+            ->setRequest($request)
+            ->findAllPaginated();
+    }
+```

--- a/src/Mado/QueryBundle/Repositories/BaseRepository.php
+++ b/src/Mado/QueryBundle/Repositories/BaseRepository.php
@@ -264,6 +264,17 @@ class BaseRepository extends EntityRepository
         return $this;
     }
 
+    public function findAllNoPaginated()
+    {
+        $queryBuilderFactory = $this->getQueryBuilderFactory()
+            ->filter()
+            ->sort();
+
+        $doctrineQueryBuilder = $queryBuilderFactory->getQueryBuilder();
+
+        return $doctrineQueryBuilder->getQuery()->getResult();
+    }
+    
     public function findAllPaginated()
     {
         $this->initFromQueryBuilderOptions($this->queryOptions);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.4
| Minor version?      | (2.4)
| Hotfix?       | no  
| Refactoring?  | no 
| New feature?  | yes <!-- don't forget to update src/**/CHANGELOG.md file -->
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

# New Feature: Find All No Paginated

Added a new method in BaseRepository
When you need results applying filter and sort without pagination

`public function findAllNoPaginated();`

This feature was needed to create an Excel Report, injecting results into the Excel Report
