### PR TITLE
ignore coverage because tested inside applications

### DIFF
--- a/src/Mado/QueryBundle/Repositories/BaseRepository.php
+++ b/src/Mado/QueryBundle/Repositories/BaseRepository.php
@@ -14,6 +14,7 @@ use Mado\QueryBundle\Services\Pager;
 use Pagerfanta\Adapter\DoctrineORMAdapter;
 use Symfony\Component\HttpFoundation\Request;
 
+/** @codeCoverageIgnore */
 class BaseRepository extends EntityRepository
 {
     protected $request;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Refactoring?  | yes
| Tests pass?   | yes

Just a consideration: BaseRepository is over tested inside applications that uses QueryBundle. It is useless to test it here because already tested in some other place.