### PR TITLE
add the possibility to just return the count of query results

### DIFF
--- a/CHANGELOG-2.2.md
+++ b/CHANGELOG-2.2.md
@@ -13,3 +13,4 @@ in 2.2 minor versions.
  - add [Services\FilterExtractor] extract additional filters from AdditionalFilterable
  - add [Objects\Filter] to read filter value
  - add [AdditionalFilterable] interface
+ - add the possibility to just return the count of query results

--- a/src/Mado/QueryBundle/Queries/QueryBuilderOptions.php
+++ b/src/Mado/QueryBundle/Queries/QueryBuilderOptions.php
@@ -71,4 +71,10 @@ class QueryBuilderOptions
             $this->options[$option] = PHP_INT_MAX;
         }
     }
+
+    public function requireJustCount()
+    {
+        return isset($this->options['justCount'])
+            && $this->options['justCount'] === 'true';
+    }
 }

--- a/src/Mado/QueryBundle/Repositories/BaseRepository.php
+++ b/src/Mado/QueryBundle/Repositories/BaseRepository.php
@@ -276,9 +276,16 @@ class BaseRepository extends EntityRepository
         $queryBuilder = $this->queryBuilderFactory->getQueryBuilder();
 
         if ($this->queryOptions->requireJustCount()) {
-            return [
-                'count' => count($queryBuilder->getQuery()->getScalarResult()),
-            ];
+            $metadata = $this->metadata;
+            $rootEntityAlias = $metadata->getEntityAlias();
+            $select = 'count(' . $rootEntityAlias . '.id)';
+
+            $count = $queryBuilder
+                ->select($select)
+                ->getQuery()
+                ->getSingleScalarResult();
+
+            return [ 'count' => $count ];
         }
 
         $this->lastQuery = $queryBuilder->getQuery()->getSql();

--- a/src/Mado/QueryBundle/Repositories/BaseRepository.php
+++ b/src/Mado/QueryBundle/Repositories/BaseRepository.php
@@ -171,6 +171,7 @@ class BaseRepository extends EntityRepository
         $select = $request->query->get('select', $this->metadata->getEntityAlias());
         $filtering = $request->query->get('filtering', '');
         $limit = $request->query->get('limit', '');
+        $justCount = $request->query->get('justCount', 'false');
 
         $this->ensureFilterIsValid($filters);
         $filters = array_merge($filters, $filter);
@@ -202,6 +203,7 @@ class BaseRepository extends EntityRepository
             'rel' => $rel,
             'printing' => $printing,
             'select' => $select,
+            'justCount' => $justCount,
         ]);
 
         return $this;
@@ -272,6 +274,12 @@ class BaseRepository extends EntityRepository
         $this->queryBuilderFactory->sort();
 
         $queryBuilder = $this->queryBuilderFactory->getQueryBuilder();
+
+        if ($this->queryOptions->requireJustCount()) {
+            return [
+                'count' => count($queryBuilder->getQuery()->getScalarResult()),
+            ];
+        }
 
         $this->lastQuery = $queryBuilder->getQuery()->getSql();
         $this->lastParameters = $queryBuilder->getQuery()->getParameters();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.2
| Minor version?      | (2.2) 
| New feature?  | yes 
| BC breaks?    |no
| Deprecations? | no 
| Tests pass?   | yes

This PR aims to return just the count of query instead of complete response. So, .. to get the number of result of a query builded with QueryBundle, .. .just add `justCount`