### PR TITLE
start moving out from BaseRepository the responsibility to build

### DIFF
--- a/src/Mado/QueryBundle/Queries/Options/QueryOptionsBuilder.php
+++ b/src/Mado/QueryBundle/Queries/Options/QueryOptionsBuilder.php
@@ -113,19 +113,19 @@ class QueryOptionsBuilder
         }
 
         return QueryBuilderOptions::fromArray([
-            '_route' => $request->attributes->get('_route'),
+            '_route'        => $request->attributes->get('_route'),
             '_route_params' => $request->attributes->get('_route_params', []),
-            'id' => $request->attributes->get('id'),
-            'filtering' => $filtering,
-            'limit' => $limit,
-            'page' => $page,
-            'filters' => $filters,
-            'orFilters' => $filterOrCorrected,
-            'sorting' => $sorting,
-            'rel' => $rel,
-            'printing' => $printing,
-            'select' => $select,
-            'justCount' => $justCount,
+            'id'            => $request->attributes->get('id'),
+            'filtering'     => $filtering,
+            'limit'         => $limit,
+            'page'          => $page,
+            'filters'       => $filters,
+            'orFilters'     => $filterOrCorrected,
+            'sorting'       => $sorting,
+            'rel'           => $rel,
+            'printing'      => $printing,
+            'select'        => $select,
+            'justCount'     => $justCount,
         ]);
     }
 
@@ -141,4 +141,49 @@ class QueryOptionsBuilder
         }
     }
 
+    public function buildForOrFilter(Request $request, $orFilter)
+    {
+        $this->ensureEntityAliasIsDefined();
+
+        $filters   = $request->query->get('filtering', []);
+        $orFilters = $request->query->get('filtering_or', []);
+        $sorting   = $request->query->get('sorting', []);
+        $printing  = $request->query->get('printing', []);
+        $rel       = $request->query->get('rel', '');
+        $page      = $request->query->get('page', '');
+        $select    = $request->query->get('select', $this->getEntityAlias());
+        $filtering = $request->query->get('filtering', '');
+        $limit     = $request->query->get('limit', '');
+
+        $orFilters = array_merge($orFilters, $orFilter);
+
+        $filterOrCorrected = [];
+
+        $count = 0;
+        foreach ($orFilters as $key => $filter) {
+            if (is_array($filter)) {
+                foreach ($filter as $keyInternal => $internal) {
+                    $filterOrCorrected[$keyInternal . '|' . $count] = $internal;
+                    $count += 1;
+                }
+            } else {
+                $filterOrCorrected[$key] = $filter;
+            }
+        }
+
+        return QueryBuilderOptions::fromArray([
+            '_route'        => $request->attributes->get('_route'),
+            '_route_params' => $request->attributes->get('_route_params', []),
+            'id'            => $request->attributes->get('id'),
+            'filtering'     => $filtering,
+            'limit'         => $limit,
+            'page'          => $page,
+            'filters'       => $filters,
+            'orFilters'     => $filterOrCorrected,
+            'sorting'       => $sorting,
+            'rel'           => $rel,
+            'printing'      => $printing,
+            'select'        => $select,
+        ]);
+    }
 }

--- a/src/Mado/QueryBundle/Queries/Options/QueryOptionsBuilder.php
+++ b/src/Mado/QueryBundle/Queries/Options/QueryOptionsBuilder.php
@@ -147,7 +147,7 @@ class QueryOptionsBuilder
         }
     }
 
-    public function buildForOrFilter(Request $request, $orFilter)
+    public function buildForOrFilter(Request $request, array $orFilter)
     {
         $this->ensureEntityAliasIsDefined();
 

--- a/src/Mado/QueryBundle/Queries/Options/QueryOptionsBuilder.php
+++ b/src/Mado/QueryBundle/Queries/Options/QueryOptionsBuilder.php
@@ -3,6 +3,7 @@
 namespace Mado\QueryBundle\Queries\Options;
 
 use Mado\QueryBundle\Exceptions\InvalidFiltersException;
+use Symfony\Component\HttpFoundation\Request;
 
 class QueryOptionsBuilder
 {

--- a/src/Mado/QueryBundle/Queries/Options/QueryOptionsBuilder.php
+++ b/src/Mado/QueryBundle/Queries/Options/QueryOptionsBuilder.php
@@ -2,6 +2,8 @@
 
 namespace Mado\QueryBundle\Queries\Options;
 
+use Mado\QueryBundle\Exceptions\InvalidFiltersException;
+
 class QueryOptionsBuilder
 {
     private $entityAlias;
@@ -76,4 +78,67 @@ class QueryOptionsBuilder
             );
         }
     }
+
+    public function buildFromRequestAndCustomFilter(Request $request, $filter)
+    {
+        $this->ensureEntityAliasIsDefined();
+
+        $filters   = $request->query->get('filtering', []);
+        $orFilters = $request->query->get('filtering_or', []);
+        $sorting   = $request->query->get('sorting', []);
+        $printing  = $request->query->get('printing', []);
+        $rel       = $request->query->get('rel', '');
+        $page      = $request->query->get('page', '');
+        $select    = $request->query->get('select', $this->getEntityAlias());
+        $filtering = $request->query->get('filtering', '');
+        $limit     = $request->query->get('limit', '');
+        $justCount = $request->query->get('justCount', 'false');
+
+        $this->ensureFilterIsValid($filters);
+
+        $filters = array_merge($filters, $filter);
+
+        $filterOrCorrected = [];
+
+        $count = 0;
+        foreach ($orFilters as $key => $filterValue) {
+            if (is_array($filterValue)) {
+                foreach ($filterValue as $keyInternal => $internal) {
+                    $filterOrCorrected[$keyInternal . '|' . $count] = $internal;
+                    $count += 1;
+                }
+            } else {
+                $filterOrCorrected[$key] = $filterValue;
+            }
+        }
+
+        return QueryBuilderOptions::fromArray([
+            '_route' => $request->attributes->get('_route'),
+            '_route_params' => $request->attributes->get('_route_params', []),
+            'id' => $request->attributes->get('id'),
+            'filtering' => $filtering,
+            'limit' => $limit,
+            'page' => $page,
+            'filters' => $filters,
+            'orFilters' => $filterOrCorrected,
+            'sorting' => $sorting,
+            'rel' => $rel,
+            'printing' => $printing,
+            'select' => $select,
+            'justCount' => $justCount,
+        ]);
+    }
+
+    private function ensureFilterIsValid($filters)
+    {
+        if (!is_array($filters)) {
+            throw new InvalidFiltersException(
+                "Wrong query string exception: "
+                . var_export($filters, true) . "\n\n"
+                . "Please check query string should be something like "
+                . "http://<host>:<port>/?filtering[<field>|<operator>]=<value>"
+            );
+        }
+    }
+
 }

--- a/src/Mado/QueryBundle/Queries/Options/QueryOptionsBuilder.php
+++ b/src/Mado/QueryBundle/Queries/Options/QueryOptionsBuilder.php
@@ -20,7 +20,7 @@ class QueryOptionsBuilder
         return $this->entityAlias;
     }
 
-    public function builderFromRequest(Request $request = null)
+    public function fromRequest(Request $request = null)
     {
         $this->ensureEntityAliasIsDefined();
 

--- a/src/Mado/QueryBundle/Queries/Options/QueryOptionsBuilder.php
+++ b/src/Mado/QueryBundle/Queries/Options/QueryOptionsBuilder.php
@@ -28,8 +28,7 @@ class QueryOptionsBuilder
         foreach ($request->attributes->all() as $attributeName => $attributeValue) {
             $requestAttributes[$attributeName] = $request->attributes->get(
                 $attributeName,
-                $attributeValue
-            );
+                $attributeValue);
         }
 
         $filters     = $request->query->get('filtering', []);

--- a/src/Mado/QueryBundle/Queries/Options/QueryOptionsBuilder.php
+++ b/src/Mado/QueryBundle/Queries/Options/QueryOptionsBuilder.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Mado\QueryBundle\Queries\Options;
+
+class QueryOptionsBuilder
+{
+    private $entityAlias;
+
+    public function setEntityAlias(string $entityAlias)
+    {
+        $this->entityAlias = $entityAlias;
+    }
+
+    public function builderFromRequest(Request $request = null)
+    {
+        $this->ensureEntityAliasIsDefined();
+
+        $requestAttributes = [];
+        foreach ($request->attributes->all() as $attributeName => $attributeValue) {
+            $requestAttributes[$attributeName] = $request->attributes->get(
+                $attributeName,
+                $attributeValue
+            );
+        }
+
+        $filters     = $request->query->get('filtering', []);
+        $orFilters   = $request->query->get('filtering_or', []);
+        $sorting     = $request->query->get('sorting', []);
+        $printing    = $request->query->get('printing', []);
+        $rel         = $request->query->get('rel', '');
+        $page        = $request->query->get('page', '');
+        $select      = $request->query->get('select', $this->getEntityAlias());
+        $filtering   = $request->query->get('filtering', '');
+        $limit       = $request->query->get('limit', '');
+
+        $filterOrCorrected = [];
+
+        $count = 0;
+        foreach ($orFilters as $key => $filter) {
+            if (is_array($filter)) {
+                foreach ($filter as $keyInternal => $internal) {
+                    $filterOrCorrected[$keyInternal . '|' . $count] = $internal;
+                    $count += 1;
+                }
+            } else {
+                $filterOrCorrected[$key] = $filter;
+            }
+        }
+
+        $requestProperties = [
+            'filtering'   => $filtering,
+            'orFiltering' => $filterOrCorrected,
+            'limit'       => $limit,
+            'page'        => $page,
+            'filters'     => $filters,
+            'orFilters'   => $filterOrCorrected,
+            'sorting'     => $sorting,
+            'rel'         => $rel,
+            'printing'    => $printing,
+            'select'      => $select,
+        ];
+
+        $options = array_merge(
+            $requestAttributes,
+            $requestProperties
+        );
+
+        return QueryBuilderOptions::fromArray($options);
+    }
+
+    public function ensureEntityAliasIsDefined()
+    {
+        if (!$this->entityAlias) {
+            throw new \RuntimeException(
+                'Oops! Entity alias is missing'
+            );
+        }
+    }
+}

--- a/src/Mado/QueryBundle/Queries/Options/QueryOptionsBuilder.php
+++ b/src/Mado/QueryBundle/Queries/Options/QueryOptionsBuilder.php
@@ -3,6 +3,7 @@
 namespace Mado\QueryBundle\Queries\Options;
 
 use Mado\QueryBundle\Exceptions\InvalidFiltersException;
+use Mado\QueryBundle\Queries\QueryBuilderOptions;
 use Symfony\Component\HttpFoundation\Request;
 
 class QueryOptionsBuilder

--- a/src/Mado/QueryBundle/Queries/Options/QueryOptionsBuilder.php
+++ b/src/Mado/QueryBundle/Queries/Options/QueryOptionsBuilder.php
@@ -14,6 +14,11 @@ class QueryOptionsBuilder
         $this->entityAlias = $entityAlias;
     }
 
+    public function getEntityAlias()
+    {
+        return $this->entityAlias;
+    }
+
     public function builderFromRequest(Request $request = null)
     {
         $this->ensureEntityAliasIsDefined();

--- a/src/Mado/QueryBundle/Repositories/BaseRepository.php
+++ b/src/Mado/QueryBundle/Repositories/BaseRepository.php
@@ -49,9 +49,9 @@ class BaseRepository extends EntityRepository
 
         $this->queryBuilderFactory = new QueryBuilderFactory($this->getEntityManager());
 
-        $this->qoBuilder = new QueryOptionsBuilder();
+        $this->queryOptionBuilder = new QueryOptionsBuilder();
         $entityAlias = $this->metadata->getEntityAlias();
-        $this->qoBuilder->setEntityAlias($entityAlias);
+        $this->queryOptionBuilder->setEntityAlias($entityAlias);
     }
 
     public function initFromQueryBuilderOptions(QueryBuilderOptions $options)
@@ -101,21 +101,21 @@ class BaseRepository extends EntityRepository
 
     public function setQueryOptionsFromRequest(Request $request = null)
     {
-        $this->queryOptions = $this->qoBuilder->builderFromRequest($request);
+        $this->queryOptions = $this->queryOptionBuilder->fromRequest($request);
 
         return $this;
     }
 
     public function setQueryOptionsFromRequestWithCustomFilter(Request $request = null, $filter)
     {
-        $this->queryOptions = $this->qoBuilder->buildFromRequestAndCustomFilter($request, $filter);
+        $this->queryOptions = $this->queryOptionBuilder->buildFromRequestAndCustomFilter($request, $filter);
 
         return $this;
     }
 
     public function setQueryOptionsFromRequestWithCustomOrFilter(Request $request = null, $orFilter)
     {
-        $this->queryOptions = $this->qoBuilder->buildForOrFilter($request);
+        $this->queryOptions = $this->queryOptionBuilder->buildForOrFilter($request);
 
         return $this;
     }

--- a/src/Mado/QueryBundle/Repositories/BaseRepository.php
+++ b/src/Mado/QueryBundle/Repositories/BaseRepository.php
@@ -10,7 +10,7 @@ use Mado\QueryBundle\Objects\MetaDataAdapter;
 use Mado\QueryBundle\Objects\PagerfantaBuilder;
 use Mado\QueryBundle\Queries\QueryBuilderFactory;
 use Mado\QueryBundle\Queries\QueryBuilderOptions;
-use Mado\QueryBundle\Queries\QueryOptionsBuilder;
+use Mado\QueryBundle\Queries\Options\QueryOptionsBuilder;
 use Mado\QueryBundle\Services\Pager;
 use Pagerfanta\Adapter\DoctrineORMAdapter;
 use Symfony\Component\HttpFoundation\Request;

--- a/src/Mado/QueryBundle/Repositories/BaseRepository.php
+++ b/src/Mado/QueryBundle/Repositories/BaseRepository.php
@@ -115,46 +115,7 @@ class BaseRepository extends EntityRepository
 
     public function setQueryOptionsFromRequestWithCustomOrFilter(Request $request = null, $orFilter)
     {
-        $filters = $request->query->get('filtering', []);
-        $orFilters = $request->query->get('filtering_or', []);
-        $sorting = $request->query->get('sorting', []);
-        $printing = $request->query->get('printing', []);
-        $rel = $request->query->get('rel', '');
-        $page = $request->query->get('page', '');
-        $select = $request->query->get('select', $this->metadata->getEntityAlias());
-        $filtering = $request->query->get('filtering', '');
-        $limit = $request->query->get('limit', '');
-
-        $orFilters = array_merge($orFilters, $orFilter);
-
-        $filterOrCorrected = [];
-
-        $count = 0;
-        foreach ($orFilters as $key => $filter) {
-            if (is_array($filter)) {
-                foreach ($filter as $keyInternal => $internal) {
-                    $filterOrCorrected[$keyInternal . '|' . $count] = $internal;
-                    $count += 1;
-                }
-            } else {
-                $filterOrCorrected[$key] = $filter;
-            }
-        }
-
-        $this->queryOptions = QueryBuilderOptions::fromArray([
-            '_route' => $request->attributes->get('_route'),
-            '_route_params' => $request->attributes->get('_route_params', []),
-            'id' => $request->attributes->get('id'),
-            'filtering' => $filtering,
-            'limit' => $limit,
-            'page' => $page,
-            'filters' => $filters,
-            'orFilters' => $filterOrCorrected,
-            'sorting' => $sorting,
-            'rel' => $rel,
-            'printing' => $printing,
-            'select' => $select,
-        ]);
+        $this->queryOptions = $this->qoBuilder->buildForOrFilter($request);
 
         return $this;
     }

--- a/tests/Mado/QueryBundle/Queries/Objects/QueryOptionsBuilderTest.php
+++ b/tests/Mado/QueryBundle/Queries/Objects/QueryOptionsBuilderTest.php
@@ -53,7 +53,7 @@ class QueryOptionsBuilderTest extends TestCase
 
         $this->builder = new QueryOptionsBuilder();
         $this->builder->setEntityAlias($alias = 'asdf');
-        $options = $this->builder->builderFromRequest($this->request);
+        $options = $this->builder->fromRequest($this->request);
 
         $this->assertEquals(
             QueryBuilderOptions::fromArray([
@@ -104,7 +104,7 @@ class QueryOptionsBuilderTest extends TestCase
 
         $this->builder = new QueryOptionsBuilder();
         $this->builder->setEntityAlias($alias = 'asdf');
-        $options = $this->builder->builderFromRequest($this->request);
+        $options = $this->builder->fromRequest($this->request);
 
         $this->assertEquals(
             QueryBuilderOptions::fromArray([
@@ -162,7 +162,7 @@ class QueryOptionsBuilderTest extends TestCase
 
         $this->builder = new QueryOptionsBuilder();
         $this->builder->setEntityAlias($alias = 'asdf');
-        $options = $this->builder->builderFromRequest($this->request);
+        $options = $this->builder->fromRequest($this->request);
 
         $this->assertEquals(
             QueryBuilderOptions::fromArray([

--- a/tests/Mado/QueryBundle/Queries/Objects/QueryOptionsBuilderTest.php
+++ b/tests/Mado/QueryBundle/Queries/Objects/QueryOptionsBuilderTest.php
@@ -1,0 +1,514 @@
+<?php
+
+use Mado\QueryBundle\Queries\Options\QueryOptionsBuilder;
+use Mado\QueryBundle\Queries\QueryBuilderOptions;
+use PHPUnit\Framework\TestCase;
+
+class QueryOptionsBuilderTest extends TestCase
+{
+    public function testShouldProvideSetterAndGettersForEntityAlias()
+    {
+        $this->builder = new QueryOptionsBuilder();
+        $this->builder->setEntityAlias($alias = 'asdf');
+        $this->assertEquals(
+            $alias,
+            $this->builder->getEntityAlias()
+        );
+    }
+
+    /** @expectedException \RuntimeException */
+    public function testRequireEntityAliasDefinition()
+    {
+        $this->builder = new QueryOptionsBuilder();
+        $this->builder->ensureEntityAliasIsDefined();
+    }
+
+    public function testShouldBuildOptionsFromEmtpyRequest()
+    {
+        $this->request = $this
+            ->getMockBuilder('Symfony\Component\HttpFoundation\Request')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->request->attributes = $this
+            ->getMockBuilder('Symfony\Component\HttpFoundation\ParameterBag')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->request->attributes->expects($this->once())
+            ->method('all')
+            ->willReturn([]);
+        $this->request->query = $this
+            ->getMockBuilder('Symfony\Component\HttpFoundation\ParameterBag')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->request->query->expects($this->at(0))->method('get')->with('filtering', [])->willReturn([]);
+        $this->request->query->expects($this->at(1))->method('get')->with('filtering_or', [])->willReturn([]);
+        $this->request->query->expects($this->at(2))->method('get')->with('sorting', [])->willReturn([]);
+        $this->request->query->expects($this->at(3))->method('get')->with('printing', [])->willReturn([]);
+        $this->request->query->expects($this->at(4))->method('get')->with('rel', '')->willReturn([]);
+        $this->request->query->expects($this->at(5))->method('get')->with('page', '')->willReturn([]);
+        $this->request->query->expects($this->at(6))->method('get')->with('select', 'asdf')->willReturn([]);
+        $this->request->query->expects($this->at(7))->method('get')->with('filtering', '')->willReturn([]);
+        $this->request->query->expects($this->at(8))->method('get')->with('limit', '')->willReturn([]);
+
+        $this->builder = new QueryOptionsBuilder();
+        $this->builder->setEntityAlias($alias = 'asdf');
+        $options = $this->builder->builderFromRequest($this->request);
+
+        $this->assertEquals(
+            QueryBuilderOptions::fromArray([
+                'filtering' => [],
+                'orFilters' => [],
+                'limit' => [],
+                'page' => [],
+                'filters' => [],
+                'orFiltering' => [],
+                'sorting' => [],
+                'rel' => [],
+                'printing' => [],
+                'select' => [],
+            ]),
+            $options
+        );
+    }
+
+    public function testFilteringOrIsConvertedInBothOriltersAndOrfiltering()
+    {
+        $this->request = $this
+            ->getMockBuilder('Symfony\Component\HttpFoundation\Request')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->request->attributes = $this
+            ->getMockBuilder('Symfony\Component\HttpFoundation\ParameterBag')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->request->attributes->expects($this->once())
+            ->method('all')
+            ->willReturn([]);
+        $this->request->query = $this
+            ->getMockBuilder('Symfony\Component\HttpFoundation\ParameterBag')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->request->query->expects($this->at(0))->method('get')->with('filtering', [])->willReturn([]);
+        $this->request->query->expects($this->at(1))->method('get')->with('filtering_or', [])->willReturn([
+            'foo' => 'bar',
+        ]);
+        $this->request->query->expects($this->at(2))->method('get')->with('sorting', [])->willReturn([]);
+        $this->request->query->expects($this->at(3))->method('get')->with('printing', [])->willReturn([]);
+        $this->request->query->expects($this->at(4))->method('get')->with('rel', '')->willReturn([]);
+        $this->request->query->expects($this->at(5))->method('get')->with('page', '')->willReturn([]);
+        $this->request->query->expects($this->at(6))->method('get')->with('select', 'asdf')->willReturn([]);
+        $this->request->query->expects($this->at(7))->method('get')->with('filtering', '')->willReturn([]);
+        $this->request->query->expects($this->at(8))->method('get')->with('limit', '')->willReturn([]);
+
+        $this->builder = new QueryOptionsBuilder();
+        $this->builder->setEntityAlias($alias = 'asdf');
+        $options = $this->builder->builderFromRequest($this->request);
+
+        $this->assertEquals(
+            QueryBuilderOptions::fromArray([
+                'filtering' => [],
+                'orFilters' => [
+                    'foo' => 'bar',
+                ],
+                'limit' => [],
+                'page' => [],
+                'filters' => [],
+                'orFiltering' => [
+                    'foo' => 'bar',
+                ],
+                'sorting' => [],
+                'rel' => [],
+                'printing' => [],
+                'select' => [],
+            ]),
+            $options
+        );
+    }
+
+    public function testAdjustOrFilteringWheneverIsAnArray()
+    {
+        $this->request = $this
+            ->getMockBuilder('Symfony\Component\HttpFoundation\Request')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->request->attributes = $this
+            ->getMockBuilder('Symfony\Component\HttpFoundation\ParameterBag')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->request->attributes->expects($this->once())
+            ->method('all')
+            ->willReturn([]);
+        $this->request->query = $this
+            ->getMockBuilder('Symfony\Component\HttpFoundation\ParameterBag')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->request->query->expects($this->at(0))->method('get')->with('filtering', [])->willReturn([]);
+        $this->request->query->expects($this->at(1))->method('get')->with('filtering_or', [])->willReturn([
+            'foo' => [
+                'bar',
+                'foo',
+            ]
+        ]);
+        $this->request->query->expects($this->at(2))->method('get')->with('sorting', [])->willReturn([]);
+        $this->request->query->expects($this->at(3))->method('get')->with('printing', [])->willReturn([]);
+        $this->request->query->expects($this->at(4))->method('get')->with('rel', '')->willReturn([]);
+        $this->request->query->expects($this->at(5))->method('get')->with('page', '')->willReturn([]);
+        $this->request->query->expects($this->at(6))->method('get')->with('select', 'asdf')->willReturn([]);
+        $this->request->query->expects($this->at(7))->method('get')->with('filtering', '')->willReturn([]);
+        $this->request->query->expects($this->at(8))->method('get')->with('limit', '')->willReturn([]);
+
+        $this->builder = new QueryOptionsBuilder();
+        $this->builder->setEntityAlias($alias = 'asdf');
+        $options = $this->builder->builderFromRequest($this->request);
+
+        $this->assertEquals(
+            QueryBuilderOptions::fromArray([
+                'filtering' => [],
+                'orFilters' => [
+                    '0|0' => 'bar',
+                    '1|1' => 'foo',
+                ],
+                'limit' => [],
+                'page' => [],
+                'filters' => [],
+                'orFiltering' => [
+                    '0|0' => 'bar',
+                    '1|1' => 'foo',
+                ],
+                'sorting' => [],
+                'rel' => [],
+                'printing' => [],
+                'select' => [],
+            ]),
+            $options
+        );
+    }
+
+    public function testShouldBuildOptionsFromEmptyRequestAndCustomFilters()
+    {
+        $this->request = $this
+            ->getMockBuilder('Symfony\Component\HttpFoundation\Request')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->request->attributes = $this
+            ->getMockBuilder('Symfony\Component\HttpFoundation\ParameterBag')
+            ->disableOriginalConstructor()
+            ->getMock();
+        //$this->request->attributes->expects($this->once())
+            //->method('all')
+            //->willReturn([]);
+        $this->request->query = $this
+            ->getMockBuilder('Symfony\Component\HttpFoundation\ParameterBag')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->request->query->expects($this->at(0))->method('get')->with('filtering', [])->willReturn([]);
+        $this->request->query->expects($this->at(1))->method('get')->with('filtering_or', [])->willReturn([]);
+        $this->request->query->expects($this->at(2))->method('get')->with('sorting', [])->willReturn([]);
+        $this->request->query->expects($this->at(3))->method('get')->with('printing', [])->willReturn([]);
+        $this->request->query->expects($this->at(4))->method('get')->with('rel', '')->willReturn([]);
+        $this->request->query->expects($this->at(5))->method('get')->with('page', '')->willReturn([]);
+        $this->request->query->expects($this->at(6))->method('get')->with('select', 'asdf')->willReturn([]);
+        $this->request->query->expects($this->at(7))->method('get')->with('filtering', '')->willReturn([]);
+        $this->request->query->expects($this->at(8))->method('get')->with('limit', '')->willReturn([]);
+
+        $this->builder = new QueryOptionsBuilder();
+        $this->builder->setEntityAlias($alias = 'asdf');
+        $options = $this->builder->buildFromRequestAndCustomFilter($this->request, [
+            'custom' => 'filter',
+        ]);
+
+        $this->assertEquals(
+            QueryBuilderOptions::fromArray([
+                'filtering' => [],
+                'orFilters' => [],
+                'limit' => [],
+                'page' => [],
+                'filters' => [
+                    'custom' => 'filter',
+                ],
+                '_route_params' => null,
+                'sorting' => [],
+                'rel' => [],
+                'printing' => [],
+                'select' => [],
+                'justCount' => null,
+                'id' => null,
+                '_route' => null,
+            ]),
+            $options
+        );
+    }
+
+    public function testShouldBuildQueryWithOrfiltersAndCustomFilters()
+    {
+        $this->request = $this
+            ->getMockBuilder('Symfony\Component\HttpFoundation\Request')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->request->attributes = $this
+            ->getMockBuilder('Symfony\Component\HttpFoundation\ParameterBag')
+            ->disableOriginalConstructor()
+            ->getMock();
+        //$this->request->attributes->expects($this->once())
+            //->method('all')
+            //->willReturn([]);
+        $this->request->query = $this
+            ->getMockBuilder('Symfony\Component\HttpFoundation\ParameterBag')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->request->query->expects($this->at(0))->method('get')->with('filtering', [])->willReturn([]);
+        $this->request->query->expects($this->at(1))->method('get')->with('filtering_or', [])->willReturn([
+            'foo' => 'bar',
+        ]);
+        $this->request->query->expects($this->at(2))->method('get')->with('sorting', [])->willReturn([]);
+        $this->request->query->expects($this->at(3))->method('get')->with('printing', [])->willReturn([]);
+        $this->request->query->expects($this->at(4))->method('get')->with('rel', '')->willReturn([]);
+        $this->request->query->expects($this->at(5))->method('get')->with('page', '')->willReturn([]);
+        $this->request->query->expects($this->at(6))->method('get')->with('select', 'asdf')->willReturn([]);
+        $this->request->query->expects($this->at(7))->method('get')->with('filtering', '')->willReturn([]);
+        $this->request->query->expects($this->at(8))->method('get')->with('limit', '')->willReturn([]);
+
+        $this->builder = new QueryOptionsBuilder();
+        $this->builder->setEntityAlias($alias = 'asdf');
+        $options = $this->builder->buildFromRequestAndCustomFilter($this->request, [
+            'custom' => 'filter',
+        ]);
+
+        $this->assertEquals(
+            QueryBuilderOptions::fromArray([
+                'filtering' => [],
+                'orFilters' => [
+                    'foo' => 'bar',
+                ],
+                'limit' => [],
+                'page' => [],
+                'filters' => [
+                    'custom' => 'filter',
+                ],
+                '_route_params' => null,
+                'sorting' => [],
+                'rel' => [],
+                'printing' => [],
+                'select' => [],
+                'justCount' => null,
+                'id' => null,
+                '_route' => null,
+            ]),
+            $options
+        );
+    }
+
+    public function testBuildOptionsFromRequestWithOrFiltersAsArrayAndCustomFilters()
+    {
+        $this->request = $this
+            ->getMockBuilder('Symfony\Component\HttpFoundation\Request')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->request->attributes = $this
+            ->getMockBuilder('Symfony\Component\HttpFoundation\ParameterBag')
+            ->disableOriginalConstructor()
+            ->getMock();
+        //$this->request->attributes->expects($this->once())
+            //->method('all')
+            //->willReturn([]);
+        $this->request->query = $this
+            ->getMockBuilder('Symfony\Component\HttpFoundation\ParameterBag')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->request->query->expects($this->at(0))->method('get')->with('filtering', [])->willReturn([]);
+        $this->request->query->expects($this->at(1))->method('get')->with('filtering_or', [])->willReturn([
+            'foo' => [
+                'bar',
+                'atro',
+            ]
+        ]);
+        $this->request->query->expects($this->at(2))->method('get')->with('sorting', [])->willReturn([]);
+        $this->request->query->expects($this->at(3))->method('get')->with('printing', [])->willReturn([]);
+        $this->request->query->expects($this->at(4))->method('get')->with('rel', '')->willReturn([]);
+        $this->request->query->expects($this->at(5))->method('get')->with('page', '')->willReturn([]);
+        $this->request->query->expects($this->at(6))->method('get')->with('select', 'asdf')->willReturn([]);
+        $this->request->query->expects($this->at(7))->method('get')->with('filtering', '')->willReturn([]);
+        $this->request->query->expects($this->at(8))->method('get')->with('limit', '')->willReturn([]);
+
+        $this->builder = new QueryOptionsBuilder();
+        $this->builder->setEntityAlias($alias = 'asdf');
+        $options = $this->builder->buildFromRequestAndCustomFilter($this->request, [
+            'custom' => 'filter',
+        ]);
+
+        $this->assertEquals(
+            QueryBuilderOptions::fromArray([
+                'filtering' => [],
+                'orFilters' => [
+                    '0|0' => 'bar',
+                    '1|1' => 'atro',
+                ],
+                'limit' => [],
+                'page' => [],
+                'filters' => [
+                    'custom' => 'filter',
+                ],
+                '_route_params' => null,
+                'sorting' => [],
+                'rel' => [],
+                'printing' => [],
+                'select' => [],
+                'justCount' => null,
+                'id' => null,
+                '_route' => null,
+            ]),
+            $options
+        );
+    }
+
+    public function testShouldBuildQueryWithOrfiltersAndCustomOrFilters()
+    {
+        $this->request = $this
+            ->getMockBuilder('Symfony\Component\HttpFoundation\Request')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->request->attributes = $this
+            ->getMockBuilder('Symfony\Component\HttpFoundation\ParameterBag')
+            ->disableOriginalConstructor()
+            ->getMock();
+        //$this->request->attributes->expects($this->once())
+            //->method('all')
+            //->willReturn([]);
+        $this->request->query = $this
+            ->getMockBuilder('Symfony\Component\HttpFoundation\ParameterBag')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->request->query->expects($this->at(0))->method('get')->with('filtering', [])->willReturn([]);
+        $this->request->query->expects($this->at(1))->method('get')->with('filtering_or', [])->willReturn([]);
+        $this->request->query->expects($this->at(2))->method('get')->with('sorting', [])->willReturn([]);
+        $this->request->query->expects($this->at(3))->method('get')->with('printing', [])->willReturn([]);
+        $this->request->query->expects($this->at(4))->method('get')->with('rel', '')->willReturn([]);
+        $this->request->query->expects($this->at(5))->method('get')->with('page', '')->willReturn([]);
+        $this->request->query->expects($this->at(6))->method('get')->with('select', 'asdf')->willReturn([]);
+        $this->request->query->expects($this->at(7))->method('get')->with('filtering', '')->willReturn([]);
+        $this->request->query->expects($this->at(8))->method('get')->with('limit', '')->willReturn([]);
+
+        $this->builder = new QueryOptionsBuilder();
+        $this->builder->setEntityAlias($alias = 'asdf');
+        $options = $this->builder->buildForOrFilter($this->request, [
+            'fizz' => 'buzz',
+        ]);
+
+        $this->assertEquals(
+            QueryBuilderOptions::fromArray([
+                'filtering' => [],
+                'orFilters' => [
+                    'fizz' => 'buzz',
+                ],
+                'limit' => [],
+                'page' => [],
+                'filters' => [],
+                '_route_params' => null,
+                'sorting' => [],
+                'rel' => [],
+                'printing' => [],
+                'select' => [],
+                'id' => null,
+                '_route' => null,
+            ]),
+            $options
+        );
+    }
+
+    public function testShouldBuildQueryWithOrfiltersAsArrayAndCustomOrFilters()
+    {
+        $this->request = $this
+            ->getMockBuilder('Symfony\Component\HttpFoundation\Request')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->request->attributes = $this
+            ->getMockBuilder('Symfony\Component\HttpFoundation\ParameterBag')
+            ->disableOriginalConstructor()
+            ->getMock();
+        //$this->request->attributes->expects($this->once())
+            //->method('all')
+            //->willReturn([]);
+        $this->request->query = $this
+            ->getMockBuilder('Symfony\Component\HttpFoundation\ParameterBag')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->request->query->expects($this->at(0))->method('get')->with('filtering', [])->willReturn([]);
+        $this->request->query->expects($this->at(1))->method('get')->with('filtering_or', [])->willReturn([
+            'a' => [
+                'b',
+                'c',
+            ],
+        ]);
+        $this->request->query->expects($this->at(2))->method('get')->with('sorting', [])->willReturn([]);
+        $this->request->query->expects($this->at(3))->method('get')->with('printing', [])->willReturn([]);
+        $this->request->query->expects($this->at(4))->method('get')->with('rel', '')->willReturn([]);
+        $this->request->query->expects($this->at(5))->method('get')->with('page', '')->willReturn([]);
+        $this->request->query->expects($this->at(6))->method('get')->with('select', 'asdf')->willReturn([]);
+        $this->request->query->expects($this->at(7))->method('get')->with('filtering', '')->willReturn([]);
+        $this->request->query->expects($this->at(8))->method('get')->with('limit', '')->willReturn([]);
+
+        $this->builder = new QueryOptionsBuilder();
+        $this->builder->setEntityAlias($alias = 'asdf');
+        $options = $this->builder->buildForOrFilter($this->request, [ ]);
+
+        $this->assertEquals(
+            QueryBuilderOptions::fromArray([
+                'filtering' => [],
+                'orFilters' => [
+                    '0|0' => 'b',
+                    '1|1' => 'c',
+                ],
+                'limit' => [],
+                'page' => [],
+                'filters' => [],
+                '_route_params' => null,
+                'sorting' => [],
+                'rel' => [],
+                'printing' => [],
+                'select' => [],
+                'id' => null,
+                '_route' => null,
+            ]),
+            $options
+        );
+    }
+
+    /** @expectedException Mado\QueryBundle\Exceptions\InvalidFiltersException */
+    public function testInvalidFilterThrownException()
+    {
+        $this->request = $this
+            ->getMockBuilder('Symfony\Component\HttpFoundation\Request')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->request->attributes = $this
+            ->getMockBuilder('Symfony\Component\HttpFoundation\ParameterBag')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->request->query = $this
+            ->getMockBuilder('Symfony\Component\HttpFoundation\ParameterBag')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->request->query->expects($this->at(0))->method('get')->with('filtering', [])->willReturn('');
+        $this->request->query->expects($this->at(1))->method('get')->with('filtering_or', [])->willReturn([]);
+        $this->request->query->expects($this->at(2))->method('get')->with('sorting', [])->willReturn([]);
+        $this->request->query->expects($this->at(3))->method('get')->with('printing', [])->willReturn([]);
+        $this->request->query->expects($this->at(4))->method('get')->with('rel', '')->willReturn([]);
+        $this->request->query->expects($this->at(5))->method('get')->with('page', '')->willReturn([]);
+        $this->request->query->expects($this->at(6))->method('get')->with('select', 'asdf')->willReturn([]);
+        $this->request->query->expects($this->at(7))->method('get')->with('filtering', '')->willReturn([]);
+        $this->request->query->expects($this->at(8))->method('get')->with('limit', '')->willReturn([]);
+
+        $this->builder = new QueryOptionsBuilder();
+        $this->builder->setEntityAlias($alias = 'asdf');
+        $this->builder->buildFromRequestAndCustomFilter($this->request, []);
+    }
+}


### PR DESCRIPTION
QueryOptionsBuilder has the responsibility to build QueryBuilderOptions. Maybe before the end of this PR few names could change. I am open to suggestions. 

| Q             | A
| ------------- | ---
| Branch?       | master
| Minor version?      | (2.5)
| Hotfix?       | no 
| Refactoring?  | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes
| Tests pass?   | yes

QueryBuiderOptions is built in different places and there is a lot of duplication. This PR just aims to isolate responsibility and finally unit test the new parts.

This is not to be intended as refactoring. I mean: we are just moving responsibilities. BaseRepository is untestable. This PR aims to move out testable parts (such the responsibility to build QueryBuilderOptions component).

This list must be completed:

 - [ ] update UPGRADE file
 - [x] cover with unit tests
