### PR TITLE
add HalResponse component to wrap pure json content

### DIFF
--- a/CHANGELOG-2.5.md
+++ b/CHANGELOG-2.5.md
@@ -1,0 +1,7 @@
+CHANGELOG for 2.5
+=================
+
+This changelog references the relevant changes (bug and security fixes) done
+in 2.5 minor versions.
+
+ - feature - add new component HalResponse to wrap raw json responses

--- a/src/Mado/QueryBundle/Objects/HalResponse.php
+++ b/src/Mado/QueryBundle/Objects/HalResponse.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Mado\QueryBundle\Objects;
+
+class HalResponse
+{
+    private $json;
+
+    private function __construct(array $json)
+    {
+        $this->json = $json;
+    }
+
+    public static function fromArray(array $json)
+    {
+        return new self($json);
+    }
+
+    public function total()
+    {
+        return $this->json['total'];
+    }
+}

--- a/tests/Mado/QueryBundle/Objects/HalResponseTest.php
+++ b/tests/Mado/QueryBundle/Objects/HalResponseTest.php
@@ -1,0 +1,16 @@
+<?php
+
+use Mado\QueryBundle\Objects\HalResponse;
+use PHPUnit\Framework\TestCase;
+
+class HalResponseTest extends TestCase
+{
+    public function testExtractTotal()
+    {
+        $response = HalResponse::fromArray([
+            'total' => 42,
+        ]);
+
+        $this->assertEquals(42, $response->total());
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Minor version?      | (2.5) <!-- check composer.json file -->
| Hotfix?       | no  <!-- don't update src/**/CHANGELOG.md file -->
| BC breaks?    | no
| Deprecations? | no <!-- don't update UPGRADE-*.md file -->
| Tests pass?   | yes

This PR aims to wrap json response provided by a findAllPaginated response. So instead of convert json and detect informations everytime, it is possibile get data from this object. This component may helps also in tests when makes easy make assertions.